### PR TITLE
Fix test suite running

### DIFF
--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -1,7 +1,5 @@
 var webpackConfig = require('../build/env/dev');
 
-delete webpackConfig.entry
-
 module.exports = function (config) {
   config.set({
     browsers: ['PhantomJS'],


### PR DESCRIPTION
Deleting 'entry' doesn't allow tests to be executed (webpack error).